### PR TITLE
isText property is default false, not true

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Option Name          | Description                                    | Default
 ---------------------|------------------------------------------------|---------
 value                | The value to be edited                         | `""`
 placeholder          | Placeholder displayed when value is blank      | `""`
-isText               | Is the value HTML or plaintext?                | `true`
+isText               | Is the value HTML or plaintext?                | `false`
 stringInterpolator   | Function which processes / intercepts any updated value. Takes a string and returns the  string to be used instead.           | none
 extraClass           | String with any extra css class.               | `null`
 


### PR DESCRIPTION
According to the docs, `isText` property is `true`. This is wrong when reading the code:

````javascript
export default Ember.Component.extend({
  ....
  isText: false,
  ...
});