### PR TITLE
Added allowNewlines attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ spellcheck           | Uses browsers spellcheck, same as with `<input>` | none
 readonly             | If true, element can't be edited but is focusable | false
 disabled             | If true, element can't be edited, focused or tabbed to | false
 maxlength            | Maximum length of the input, in characters     | none
-allowNewlines        | If false, linebreaks can't be entered          | false
+allowNewlines        | If false, linebreaks can't be entered          | true
 
 ##### isText Deprecation
 isText has been deprecated. You should replace `isText=true` with `type="text"`, and `isText=false` with `type="html"`.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ spellcheck           | Uses browsers spellcheck, same as with `<input>` | none
 readonly             | If true, element can't be edited but is focusable | false
 disabled             | If true, element can't be edited, focused or tabbed to | false
 maxlength            | Maximum length of the input, in characters     | none
+allowNewlines        | If false, linebreaks can't be entered          | false
 
 ##### isText Deprecation
 isText has been deprecated. You should replace `isText=true` with `type="text"`, and `isText=false` with `type="html"`.

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -152,6 +152,16 @@ export default Ember.Component.extend({
         sel.addRange(range);
       }
     }
+
+    var value = this.get('value');
+    this.set('_observeValue', false);
+
+    if (this.get('type') === 'number') {
+      value = value.toString().replace(/[^0-9]/g, '');
+    }
+
+    this.set('value', value);
+    this.set('_observeValue', true);
   },
 
   keyDown(event) {

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -31,6 +31,7 @@ export default Ember.Component.extend({
   isText: null,
   type: null,
   readonly: null,
+  allowNewlines: true,
 
   inputType: Ember.computed('type', 'isText', function() {
     if (this.get('isText') !== null) {
@@ -156,6 +157,10 @@ export default Ember.Component.extend({
     var value = this.get('value');
     this.set('_observeValue', false);
 
+    if (!this.get('allowNewlines')) {
+      value = value.toString().replace(/\n/g, ' ');
+    }
+
     if (this.get('type') === 'number') {
       value = value.toString().replace(/[^0-9]/g, '');
     }
@@ -176,7 +181,12 @@ export default Ember.Component.extend({
     } else if (event.keyCode === 13) {
       // Enter
       this.sendAction('enter', this, event);
-      this.sendAction('insert-newline', this, event);
+      if (this.get('allowNewlines')) {
+        this.sendAction('insert-newline', this, event);
+      } else {
+        event.preventDefault();
+        return false;
+      }
     }
 
     this.sendAction('key-down', this.get('value'), event);

--- a/tests/integration/components/content-editable-test.js
+++ b/tests/integration/components/content-editable-test.js
@@ -261,3 +261,31 @@ test('type=number works', function(assert) {
   $element.trigger($.Event("keypress", { keyCode: 49})); // Number
   $element.trigger($.Event("keypress", { keyCode: 65 })); // Not number
 });
+
+test('allowNewlines=true works', function(assert) {
+  assert.expect(2);
+  this.set('value', "");
+  this.set('keyDown', function(event) {
+    assert.ok(!event.defaultPrevented);
+  });
+
+  this.render(hbs`{{content-editable allowNewlines=true value=value key-down=keyDown}}`);
+  const $element = this.$('.ember-content-editable');
+
+  $element.trigger($.Event("keydown", { keyCode: 13})); // Enter
+  $element.trigger($.Event("keydown", { keyCode: 65 })); // Not enter
+});
+
+test('allowNewlines=false works', function(assert) {
+  assert.expect(1);
+  this.set('value', "");
+  this.set('keyDown', function(event) {
+    assert.ok(!event.defaultPrevented);
+  });
+
+  this.render(hbs`{{content-editable allowNewlines=false value=value key-down=keyDown}}`);
+  const $element = this.$('.ember-content-editable');
+
+  $element.trigger($.Event("keydown", { keyCode: 13})); // Enter
+  $element.trigger($.Event("keydown", { keyCode: 65 })); // Not enter
+});


### PR DESCRIPTION
If allowNewlines is set to false, new lines will not be inserted. If
the user presses enter, the value will not change. If the user pastes a
string with newlines, the newlines will be replaced with spaces.

Pasting non-numeric characters into a type=number content-editable will also now strip the non-numeric characters out.