### PR TITLE
Added support for autofocus

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -32,6 +32,7 @@ export default Ember.Component.extend({
   type: null,
   readonly: null,
   allowNewlines: true,
+  autofocus: false,
 
   inputType: Ember.computed('type', 'isText', function() {
     if (this.get('isText') !== null) {
@@ -56,6 +57,10 @@ export default Ember.Component.extend({
     this.$().on('paste', (event) => {
       this.handlePaste(event, this);
     });
+    
+    if (this.get('autofocus')) {
+      this.$().focus();
+    }
   }),
 
   tidy: Ember.on('willDestroyElement', function() {


### PR DESCRIPTION
If autofocus=true the element will take focus once it has been inserted into the document.
Inspired by the native autofocus attribute on input fields.