### PR TITLE
Update content-editable.js

### DIFF
--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -71,7 +71,7 @@ export default Ember.Component.extend({
 
   setValue() {
     if (this.element) {
-      this.$().text(this.get('value') || '');
+      this.$().text(Ember.isEmpty(this.get('value')) ? '' || this.get('value'));
     }
   },
 

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -71,7 +71,7 @@ export default Ember.Component.extend({
 
   setValue() {
     if (this.element) {
-      this.$().text(Ember.isEmpty(this.get('value')) ? '' || this.get('value'));
+      this.$().text(Ember.isEmpty(this.get('value')) ? '' : this.get('value'));
     }
   },
 

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -71,7 +71,7 @@ export default Ember.Component.extend({
 
   setValue() {
     if (this.element) {
-      this.$().text(this.get('value'));
+      this.$().text(this.get('value') || '');
     }
   },
 


### PR DESCRIPTION
According to this jQuery bug https://bugs.jquery.com/ticket/13666 and also the docs for `.text()` http://api.jquery.com/text/#text2 , passing in `null` or `undefined` is not valid input for the `.text()` method. This change avoids passing in either values.

In the latest jQuery, `null`s and `undefined`s are handled as regular no-ops, albeit they are undocumented (save for above links). But in past versions, the behavior is less predictable - in as recent as 1.11.3, passing in `null` will return a string `'null'`. 

Currently, we are embedding our ember app in a legacy web app, and are running into this minor complication. Refining the way we use `.text()` can help us in this situation and also help adhere more strictly to jQuery docs.