### PR TITLE
Preserve placeholder on initial focus. Make opposite behavior a config option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4.2.4"
 
-sudo: false
+sudo: required
+dist: trusty
 
 cache:
   directories:
@@ -21,12 +22,19 @@ matrix:
     - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
-  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
-  - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - export CHROME_BIN=/usr/bin/google-chrome
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sudo apt-get update
+  - sudo apt-get install -y libappindicator1 fonts-liberation
+  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  - sudo dpkg -i google-chrome*.deb
+  - npm config set progress false
+  - npm install -g bower
+  - npm install -g npm@^3
+
 
 install:
-  - npm install -g bower
   - npm install
   - bower install
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ disabled             | If true, element can't be edited, focused or tabbed to | 
 maxlength            | Maximum length of the input, in characters     | none
 allowNewlines        | If false, linebreaks can't be entered          | true
 autofocus            | If true, the element will be focused once inserted into the document | false
+clearPlaceholderOnFocus | If true, the placeholder will be cleared as soon as the element gains focus (even if no content is present yet) | false
 
 ##### isText Deprecation
 isText has been deprecated. You should replace `isText=true` with `type="text"`, and `isText=false` with `type="html"`.

--- a/addon/components/content-editable.js
+++ b/addon/components/content-editable.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
   classNames: ['ember-content-editable'],
-  classNameBindings: ['extraClass'],
+  classNameBindings: ['extraClass', 'clearPlaceholderOnFocus:clear-on-focus'],
   attributeBindings: [
     'contenteditable',
     'placeholder',
@@ -33,6 +33,7 @@ export default Ember.Component.extend({
   readonly: null,
   allowNewlines: true,
   autofocus: false,
+  clearPlaceholderOnFocus: false,
 
   inputType: Ember.computed('type', 'isText', function() {
     if (this.get('isText') !== null) {
@@ -57,7 +58,7 @@ export default Ember.Component.extend({
     this.$().on('paste', (event) => {
       this.handlePaste(event, this);
     });
-    
+
     if (this.get('autofocus')) {
       this.$().focus();
     }

--- a/addon/styles/addon.css
+++ b/addon/styles/addon.css
@@ -1,5 +1,10 @@
-[contenteditable=true]:empty:not(:focus):before {
+[contenteditable=true]:empty:not(:focus):before,
+[contenteditable=true]:focus:empty:before {
   content: attr(placeholder);
+}
+
+.ember-content-editable.clear-on-focus[contenteditable=true]:empty:focus:before {
+  content: '';
 }
 
 [contenteditable=true] {

--- a/testem.json
+++ b/testem.json
@@ -3,7 +3,7 @@
   "test_page": "tests/index.html?hidepassed",
   "disable_watching": true,
   "launch_in_ci": [
-    "PhantomJS"
+    "Chrome"
   ],
   "launch_in_dev": [
     "PhantomJS",

--- a/tests/integration/components/content-editable-test.js
+++ b/tests/integration/components/content-editable-test.js
@@ -2,10 +2,9 @@ import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
 function getPlaceholderContent(element) {
-  let placeholderContent = window.getComputedStyle(element, ':before').content;
+  let placeholderContent = window.getComputedStyle(element, '::before').content;
   return placeholderContent.replace(/\"/g, ""); // presence of quotes varies in phantomjs vs chrome
 }
-
 
 moduleForComponent('content-editable', 'Integration | Component | content editable', {
   integration: true
@@ -32,8 +31,8 @@ test('it renders', function(assert) {
   assert.equal(this.$().text().trim(), 'template block text');
 });
 
-test('placeholder renders', function(assert) {
-  assert.expect(3);
+test('placeholder renders and stays on focus until the element has content', function(assert) {
+  assert.expect(5);
   this.set("value", "");
   this.render(hbs`{{content-editable value=value placeholder="bananas"}}`);
   const $element = this.$('.ember-content-editable');
@@ -45,9 +44,30 @@ test('placeholder renders', function(assert) {
   // Check CSS output
   assert.equal(getPlaceholderContent(element), 'bananas', "CSS before:content matches placeholder");
 
+  element.focus();
+
+  assert.equal($element.attr('placeholder'), "bananas", "DOM attr has correct placeholder");
+  assert.equal(getPlaceholderContent(element), 'bananas', "CSS before:content matches placeholder");
+
   // Check placeholder hidden when value is present
   this.set("value", "zebra");
+
   assert.equal(getPlaceholderContent(element), "", "Placeholder not shown when content present");
+});
+
+test('`clearPlaceholderOnFocus` option removes placeholder on intial focus', function (assert) {
+  assert.expect(2);
+  this.set("value", "");
+  this.render(hbs`{{content-editable tabindex="0" value=value placeholder="bananas" clearPlaceholderOnFocus="true"}}`);
+  const $element = this.$('.ember-content-editable');
+  const element = $element[0];
+
+  // Check CSS output
+  assert.equal(getPlaceholderContent(element), 'bananas', "CSS before:content matches placeholder");
+
+  element.focus();
+
+  assert.equal(getPlaceholderContent(element), "", "CSS before: placeholder content removed when `clearPlaceholderOnFocus` is used");
 });
 
 test('Value updated when input changes', function(assert) {


### PR DESCRIPTION
I just started using this add-on in a project (and great job, btw!), and I noticed that when using placeholders, the placeholder will be removed from the `::before` pseudo element’s content as soon as the element gains focus. This is contrary to the native behavior for placeholders in input elements ([which I made a quick demo for here](http://codepen.io/BrianSipple/pen/zqLagq)), which only clears the field when the user begins typing.

With that in mind, I’d like to suggest keeping `ember-content-editable` consistent with standard placeholder behavior by default -- but then also providing a configuration option for the opposite behavior. 

The former change is just a minor tweak to `addon.css` that accounts for `[contenteditable=true]:focus:empty:before` when applying the placeholder. The latter change would just be a classNameBinding on the config option with a corresponding CSS rule of its own:
```
    .ember-content-editable.clear-on-focus[contenteditable=true]:empty:focus:before {
      content: '';
    }
```

If these are acceptable changes, there’s one other addition I’d like to include here.

Along the way of adding tests, I discovered that PhantomJS doesn’t play too nicely with the `:focused` state of DOM elements ([there’s actually an open bug here](https://github.com/guard/guard-jasmine/issues/48)), Particularly, it doesn’t respond to the event being triggered on an in-memory Node.

This made headless tests for the `::before` content of a focused element altogether impossible -- and it lead to the test for toggling focus when `clearPlaceholderOnFocus` was `true` passing in Chrome but failing in Phantom. (Side note: For what it’s worth, I can also confirm success with the behavior of toggling `clearPlaceholderOnFocus` in a project that's using my local branch).

With `ember-content-editable`’s primary concern being so DOM-centric, I think it would be a great improvement going forward to set up Travis to run tests in Chrome. I the made changes to `travis.yml` necessary for doing so — and currently, we’re all green.